### PR TITLE
update setup.py to exclude "tests"

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
         'Topic :: Security',
     ],
     keywords='Fortinet fortigate fortios rest api',
-    packages=find_packages(),
+    packages=find_packages(exclude=['tests']),
     install_requires=['requests', 'paramiko', 'oyaml'],
     author='Nicolas Thomas',
     author_email='nthomas@fortinet.com',


### PR DESCRIPTION
otherwise it would try to install it at top level:

```
>>> Jobs: 2 of 3 complete, 1 failed                 Load avg: 0.72, 0.40, 0.28
 * Package:    dev-python/fortiosapi-1.0.5
 * Repository: HomeAssistantRepository
 * Maintainer: b@edevau.net
 * Upstream:   nthomas@fortinet.com
 * USE:        abi_x86_64 amd64 elibc_glibc kernel_linux python_targets_python3_9 test userland_GNU
 * FEATURES:   network-sandbox preserve-libs sandbox userpriv usersandbox
>>> Unpacking source...
>>> Unpacking fortiosapi-1.0.5.tar.gz to /var/tmp/portage/dev-python/fortiosapi-1.0.5/work
>>> Source unpacked in /var/tmp/portage/dev-python/fortiosapi-1.0.5/work
>>> Preparing source in /var/tmp/portage/dev-python/fortiosapi-1.0.5/work/fortiosapi-1.0.5 ...
>>> Source prepared.
>>> Configuring source in /var/tmp/portage/dev-python/fortiosapi-1.0.5/work/fortiosapi-1.0.5 ...
locale: Cannot set LC_ALL to default locale: No such file or directory
>>> Source configured.
>>> Compiling source in /var/tmp/portage/dev-python/fortiosapi-1.0.5/work/fortiosapi-1.0.5 ...
 * python3_9: running distutils-r1_run_phase distutils-r1_python_compile
python3.9 setup.py build -j 6
running build
running build_py
creating /var/tmp/portage/dev-python/fortiosapi-1.0.5/work/fortiosapi-1.0.5-python3_9/lib/tests
...
warning: no files found matching 'tests/startvm.sh'
warning: no files found matching 'tests/virsh.yaml'
writing manifest file 'fortiosapi.egg-info/SOURCES.txt'
Copying fortiosapi.egg-info to /var/tmp/portage/dev-python/fortiosapi-1.0.5/image/_python3.9/usr/lib/python3.9/site-packages/fortiosapi-1.0.5-py3.9.egg-info
running install_scripts
 * ERROR: dev-python/fortiosapi-1.0.5::HomeAssistantRepository failed (install phase):
 *   Package installs 'tests' package which is forbidden and likely a bug in the build system.
 *
 * Call stack:
 *     ebuild.sh, line  127:  Called src_install
 *   environment, line 2844:  Called distutils-r1_src_install
 *   environment, line 1181:  Called _distutils-r1_run_foreach_impl 'distutils-r1_python_install'
 *   environment, line  452:  Called python_foreach_impl 'distutils-r1_run_phase' 'distutils-r1_python_install'
 *   environment, line 2519:  Called multibuild_foreach_variant '_python_multibuild_wrapper' 'distutils-r1_run_phase' 'distutils-r1_python_install'
 *   environment, line 2050:  Called _multibuild_run '_python_multibuild_wrapper' 'distutils-r1_run_phase' 'distutils-r1_python_install'
 *   environment, line 2048:  Called _python_multibuild_wrapper 'distutils-r1_run_phase' 'distutils-r1_python_install'
 *   environment, line  766:  Called distutils-r1_run_phase 'distutils-r1_python_install'
 *   environment, line 1149:  Called distutils-r1_python_install
 *   environment, line 1052:  Called die
 ```