### PR TITLE
Add six

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
     ],
     keywords='Fortinet fortigate fortios rest api',
     packages=find_packages(),
-    install_requires=['requests', 'paramiko', 'oyaml'],
+    install_requires=['requests', 'paramiko', 'oyaml', 'six'],
     author='Nicolas Thomas',
     author_email='nthomas@fortinet.com',
     url='https://github.com/fortinet-solutions-cse/fortiosapi',


### PR DESCRIPTION
`six` is a run-time [requirement](https://github.com/fortinet-solutions-cse/fortiosapi/blob/de593924f2b1018f1bfc85d4487858bdb676ebfc/fortiosapi/fortiosapi.py#L38).