### PR TITLE
Change get call to monitor call

### DIFF
--- a/fortiosapi/fortiosapi.py
+++ b/fortiosapi/fortiosapi.py
@@ -264,7 +264,7 @@ class FortiOSAPI:
         self.timeout = timeout
 
         LOG.debug("host is %s", host)
-        resp_lic = self.get('system', 'status', vdom=vdom)
+        resp_lic = self.monitor('system', 'status', vdom=vdom)
         LOG.debug("response system/status : %s", resp_lic)
         try:
             self._fortiversion = resp_lic['version']


### PR DESCRIPTION
During the login function, a system status check is made using the GET method, but that points the call to the CMDB API endpoints which is deprecated in 7.4 and causes errors.  Swapping the call over to the monitor endpoint should fix the failures.